### PR TITLE
change range type to list because deleting range element is illegal

### DIFF
--- a/bleualign.py
+++ b/bleualign.py
@@ -605,8 +605,8 @@ class Aligner:
             oldtarget = (-1,)
 
         #identify gap sizes
-        sourcegap = range(oldsrc[-1]+1,src)
-        targetgap = range(oldtarget[-1]+1,target)
+        sourcegap = list(range(oldsrc[-1]+1,src))
+        targetgap = list(range(oldtarget[-1]+1,target))
 
         if targetgap or sourcegap:
           lastpair = self.gapfiller(sourcegap, targetgap, lastpair, ((src,),(target,)), translist, targetlist)
@@ -621,8 +621,8 @@ class Aligner:
           target = -1
 
       #search for gap after last alignment pair
-      sourcegap = range(src+1, len(translist))
-      targetgap = range(target+1, len(targetlist))
+      sourcegap = list(range(src+1, len(translist)))
+      targetgap = list(range(target+1, len(targetlist)))
 
       if targetgap or sourcegap:
         lastpair = self.gapfiller(sourcegap, targetgap, lastpair, ((),()), translist, targetlist)


### PR DESCRIPTION
Process AlignMultiprocessed-3:
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/multiprocessing/process.py", line 254, in _bootstrap
    self.run()
  File "bleualign.py", line 1137, in run
    self.multialign = self.process(sourcelist,targetlist,translist1,translist2)
  File "bleualign.py", line 380, in process
    phase1.append(self.align(translist, raw_targetlist))
  File "bleualign.py", line 444, in align
    self.gapfinder(translist, targetlist)
  File "bleualign.py", line 612, in gapfinder
    lastpair = self.gapfiller(sourcegap, targetgap, lastpair, ((src,),(target,)), translist, targetlist)
  File "bleualign.py", line 757, in gapfiller
    del(targetgap[targetgap.index(i)])
TypeError: 'range' object doesn't support item deletion
