### PR TITLE
add vscode debug support

### DIFF
--- a/bleualign/align.py
+++ b/bleualign/align.py
@@ -217,10 +217,12 @@ class Aligner:
         return outputObject, close_object
 
     #takes care of multiprocessing; calls process() function for each article
-    def mainloop(self):
-      
+    def mainloop(self, vs_debug_mode=False):
       results = {}
-
+      if vs_debug_mode == True: #vscode will raise errors unless multiprocessing is disabled.  
+        multiprocessing_enabled = False
+      else:
+        multiprocessing_enabled = True
       if multiprocessing_enabled:
         tasks = multiprocessing.Queue(number_of_threads+1)
 


### PR DESCRIPTION
A special case: when we want to debug code in vscode, multiprocessing module will throw error unless we specify multiprocessing is disabled. The performance might be affected due to the fact of disabling multiprocessing.